### PR TITLE
Add cartouches

### DIFF
--- a/Syntaxes/Isabelle.tmLanguage
+++ b/Syntaxes/Isabelle.tmLanguage
@@ -122,6 +122,14 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>‹</string>
+			<key>end</key>
+			<string>›</string>
+			<key>name</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>`</string>
 			<key>end</key>
 			<string>`</string>


### PR DESCRIPTION
Hi Gerwin,

I'm adding the cartouche syntax that has become more encouraged of late. It works fine in my Forester plugin (based on the shiki library which uses textmate grammars to highlight code snippets in JS), but I haven't actually tested it in textMate or similar.